### PR TITLE
Allow parsing of longer documents than 100k characters

### DIFF
--- a/src/Taro.jl
+++ b/src/Taro.jl
@@ -40,7 +40,7 @@ function extract(filename::AbstractString)
 	mimeType = jcall(tika, "detect",JString, (File,), f)
 
 	metadata=Metadata((),)
-	ch=BodyContentHandler((),)
+	ch=BodyContentHandler((jint,),jint(-1))
 	parser=AutoDetectParser((),)
 
 	jcall(metadata, "set", Void, (JString, JString), "Content-Type", mimeType)

--- a/src/Taro.jl
+++ b/src/Taro.jl
@@ -18,14 +18,15 @@ JavaCall.addOpts("-Djava.awt.headless=true")
 
 init() = JavaCall.init()
 """
-    extract(filename::AbstractString)
+    extract(filename::AbstractString; unsafe = false)
 
 Extract raw text from documents, using Apache Tika.
 Returns a Dict of metadata name value pairs, and a String with the text of the document.
 
-    filename: path of file to read. relative to current directory, or absolute
+    `filename`: path of file to read. relative to current directory, or absolute
+    `unsafe` : If set to true, the full contents of the file is read. If false, returned string is capped at 100 000 characters.
 """
-function extract(filename::AbstractString)
+function extract(filename::AbstractString; unsafe = false)
 	JavaCall.assertloaded()
 	File = @jimport java.io.File
 	f=File((JString,), filename)
@@ -40,7 +41,7 @@ function extract(filename::AbstractString)
 	mimeType = jcall(tika, "detect",JString, (File,), f)
 
 	metadata=Metadata((),)
-	ch=BodyContentHandler((jint,),jint(-1))
+	ch = unsafe ? BodyContentHandler((jint,),jint(-1)) : BodyContentHandler((),)
 	parser=AutoDetectParser((),)
 
 	jcall(metadata, "set", Void, (JString, JString), "Content-Type", mimeType)


### PR DESCRIPTION
References
https://github.com/chrismattmann/tika-python/issues/5
https://github.com/ahmadia/tika-python/commit/f5abd16671dd0f2f6380c5198bbfb69b7d1643d2
Solves #43