### PR TITLE
Upgrade to 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 deps/*.jar
-deps/fop-2.0
+deps/fop*
+deps/build.log
 deps/*.tar.gz
 test/simple.pdf
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
+  - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.6
-JavaCall 0.5.2
-DataFrames 0.11.5
-DataArrays 0.7.0
+julia 0.7
+JavaCall
+Tables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,17 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    JAVA_HOME: C:\Program Files\Java\jdk1.7.0\
-  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-  #  JAVA_HOME: C:\Program Files\Java\jdk1.7.0\
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
@@ -17,19 +25,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Taro\"); Pkg.build(\"Taro\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Taro\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,8 +5,8 @@ if !isfile(tika_jar)
     download("https://apache.osuosl.org/tika/tika-app-1.19.1.jar", tika_jar)
 end
 
-fop_dir = joinpath(tdeps, "fop-2.3")
-fop_jar = joinpath(fop_dir "build", "fop-2.3.jar")
+fop_dir = joinpath(tdeps, "fop-2.3", "fop")
+fop_jar = joinpath(fop_dir, "build", "fop-2.3.jar")
 fop_lib = joinpath(fop_dir, "lib" )
 fop_gz = joinpath(tdeps, "fop-2.3-bin.tar.gz")
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,8 +1,8 @@
 tdeps = dirname(@__FILE__)
-tika_jar = joinpath(tdeps, "tika-app-1.19.jar")
+tika_jar = joinpath(tdeps, "tika-app-1.20.jar")
 if !isfile(tika_jar)
-    @info "  Downloading tika-app-1.17.jar from Apache OSUOSL Mirror"
-    download("https://apache.osuosl.org/tika/tika-app-1.19.1.jar", tika_jar)
+    @info "  Downloading tika-app-1.20.jar from Apache OSUOSL Mirror"
+    download("https://apache.osuosl.org/tika/tika-app-1.20.jar", tika_jar)
 end
 
 fop_dir = joinpath(tdeps, "fop-2.3", "fop")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,20 +1,22 @@
 tdeps = dirname(@__FILE__)
-tika_jar = joinpath(tdeps, "tika-app-1.17.jar")
+tika_jar = joinpath(tdeps, "tika-app-1.19.jar")
 if !isfile(tika_jar)
-    info("  Downloading tika-app-1.17.jar from Maven Central")
-    download("http://search.maven.org/remotecontent?filepath=org/apache/tika/tika-app/1.17/tika-app-1.17.jar", tika_jar)
+    @info "  Downloading tika-app-1.17.jar from Maven Central"
+    download("https://apache.osuosl.org/tika/tika-app-1.19.1.jar", tika_jar)
 end
 
-fop_jar = joinpath(tdeps, "fop-2,2", "fop-2.2.jar")
-fop_gz = joinpath(tdeps, "fop-2.2-bin.tar.gz")
+fop_dir = joinpath(tdeps, "fop-2.3")
+fop_jar = joinpath(fop_dir "build", "fop-2.3.jar")
+fop_lib = joinpath(fop_dir, "lib" )
+fop_gz = joinpath(tdeps, "fop-2.3-bin.tar.gz")
 
 if !isfile(fop_gz)
-    info("  Downloading fop-2.2 binary from Apache OSUOSL Mirror")
-    download("http://apache.osuosl.org/xmlgraphics/fop/binaries/fop-2.0-bin.tar.gz", fop_gz)
+    @info "  Downloading fop-2.3 binary from Apache OSUOSL Mirror"
+    download("https://apache.osuosl.org/xmlgraphics/fop/binaries/fop-2.3-bin.tar.gz", fop_gz)
 end
 if !isfile(fop_jar)
-    if is_unix() unpack_cmd = `tar xzf $fop_gz --directory=$tdeps` end
-    if is_windows()
+    if Sys.isunix() unpack_cmd = `tar xzf $fop_gz --directory=$tdeps` end
+    if Sys.iswindows()
         exe7z = joinpath(JULIA_HOME, "7z.exe")
         unpack_cmd = pipeline(`$exe7z x $fop_gz -y -so`,`$exe7z x -si -y -ttar -o$tdeps`)
     end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,7 @@
 tdeps = dirname(@__FILE__)
 tika_jar = joinpath(tdeps, "tika-app-1.19.jar")
 if !isfile(tika_jar)
-    @info "  Downloading tika-app-1.17.jar from Maven Central"
+    @info "  Downloading tika-app-1.17.jar from Apache OSUOSL Mirror"
     download("https://apache.osuosl.org/tika/tika-app-1.19.1.jar", tika_jar)
 end
 
@@ -17,7 +17,7 @@ end
 if !isfile(fop_jar)
     if Sys.isunix() unpack_cmd = `tar xzf $fop_gz --directory=$tdeps` end
     if Sys.iswindows()
-        exe7z = joinpath(JULIA_HOME, "7z.exe")
+        exe7z = joinpath(Sys.BINDIR, "7z.exe")
         unpack_cmd = pipeline(`$exe7z x $fop_gz -y -so`,`$exe7z x -si -y -ttar -o$tdeps`)
     end
     run(unpack_cmd)

--- a/src/Taro.jl
+++ b/src/Taro.jl
@@ -4,7 +4,7 @@ using Dates
 using JavaCall
 using Tables
 
-tika_jar = joinpath(dirname(@__FILE__), "..", "deps", "tika-app-1.19.jar")
+tika_jar = joinpath(dirname(@__FILE__), "..", "deps", "tika-app-1.20.jar")
 fop_lib = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.3", "fop", "lib", "*")
 fop_jar = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.3","fop", "build", "fop.jar")
 

--- a/src/Taro.jl
+++ b/src/Taro.jl
@@ -1,22 +1,26 @@
 module Taro
 
+using Dates
 using JavaCall
-using DataFrames
-using DataArrays
+using Tables
 
-tika_jar = joinpath(dirname(@__FILE__), "..", "deps", "tika-app-1.17.jar")
-fop_lib = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.0", "lib", "*")
-fop_jar = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.0", "build", "fop.jar")
-
-JavaCall.addClassPath(tika_jar)
-JavaCall.addClassPath(fop_lib)
-JavaCall.addClassPath(fop_jar)
+tika_jar = joinpath(dirname(@__FILE__), "..", "deps", "tika-app-1.19.jar")
+fop_lib = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.3", "fop", "lib", "*")
+fop_jar = joinpath(dirname(@__FILE__), "..", "deps", "fop-2.3","fop", "build", "fop.jar")
 
 
-JavaCall.addOpts("-Xmx256M")
-JavaCall.addOpts("-Djava.awt.headless=true")
+function __init__()
+    JavaCall.addClassPath(tika_jar)
+    JavaCall.addClassPath(fop_lib)
+    JavaCall.addClassPath(fop_jar)
+    JavaCall.addOpts("-Xmx256M")
+    JavaCall.addOpts("-Djava.awt.headless=true")
+end
+
 
 init() = JavaCall.init()
+
+
 """
     extract(filename::AbstractString; unsafe = false)
 
@@ -44,14 +48,14 @@ function extract(filename::AbstractString; unsafe = false)
 	ch = unsafe ? BodyContentHandler((jint,),jint(-1)) : BodyContentHandler((),)
 	parser=AutoDetectParser((),)
 
-	jcall(metadata, "set", Void, (JString, JString), "Content-Type", mimeType)
+	jcall(metadata, "set", Cvoid, (JString, JString), "Content-Type", mimeType)
 	ParseContext = @jimport org.apache.tika.parser.ParseContext
 	pc = ParseContext((),)
 	ContentHandler = @jimport org.xml.sax.ContentHandler
-	jcall(parser, "parse", Void, (InputStream, ContentHandler, Metadata, ParseContext), is, ch, metadata, pc)
+	jcall(parser, "parse", Cvoid, (InputStream, ContentHandler, Metadata, ParseContext), is, ch, metadata, pc)
 	nm = jcall(metadata, "names", Array{JString,1}, (),)
     nm = map(unsafe_string, nm)
-    vs=Array{String}(length(nm))
+    vs=Array{String}(undef, length(nm))
     for i in 1:length(nm)
         vs[i] = jcall(metadata, "get", JString, (JString,), nm[i])
     end
@@ -62,10 +66,9 @@ function extract(filename::AbstractString; unsafe = false)
 
 end
 
-
-
 include("hssf.jl")
 include("fop.jl")
+@show JavaCall.opts
 
 
 end # module

--- a/src/Taro.jl
+++ b/src/Taro.jl
@@ -68,7 +68,6 @@ end
 
 include("hssf.jl")
 include("fop.jl")
-@show JavaCall.opts
 
 
 end # module

--- a/src/fop.jl
+++ b/src/fop.jl
@@ -38,6 +38,6 @@ function fo(input::AbstractString, output::AbstractString)
     handler = jcall(fop, "getDefaultHandler", @jimport(org.xml.sax.helpers.DefaultHandler), ())
     res = SAXResult((@jimport(org.xml.sax.ContentHandler),), handler)
 
-    jcall(transformer, "transform", Void, (Source, Result), src, res)
-    jcall(bout, "close", Void, ())
+    jcall(transformer, "transform", Cvoid, (Source, Result), src, res)
+    jcall(bout, "close", Cvoid, ())
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DataFrames

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,8 +19,8 @@ meta, body=Taro.extract("$(joinpath(tdir,"WhyJulia.pdf"))")
 nt=Taro.readxl("$(joinpath(tdir,"df-test.xlsx"))","Sheet1", "B2:F10")
 
 df = DataFrame(nt)
-@test 5==length(df)
-@test 8==length(df[1])
+@test 5==size(df,2)
+@test 8==size(df, 1)
 
 const writetestfile = "$(joinpath(tdir,"df-test-writexl.xlsx"))"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
-using Base.Test
+using Test
 using Taro
+using Dates
+using DataFrames
+using JavaCall
 
 tdir = dirname(@__FILE__)
 Taro.init()
@@ -13,7 +16,9 @@ meta, body=Taro.extract("$(joinpath(tdir,"WhyJulia.pdf"))")
 @test length(keys(meta)) > 30
 @test length(body)>3000
 
-df=Taro.readxl("$(joinpath(tdir,"df-test.xlsx"))","Sheet1", "B2:F10")
+nt=Taro.readxl("$(joinpath(tdir,"df-test.xlsx"))","Sheet1", "B2:F10")
+
+df = DataFrame(nt)
 @test 5==length(df)
 @test 8==length(df[1])
 
@@ -23,9 +28,9 @@ const writetestfile = "$(joinpath(tdir,"df-test-writexl.xlsx"))"
 rm(writetestfile; force=true)
 Taro.writexl(writetestfile, [df, df]; sheetnames=["t1", "t2"])
 t1 = Taro.readxl(writetestfile,"t1","A1:E9")
-@test hash(t1) == hash(df)
+@test hash(DataFrame(t1)) == hash(df)
 t2 = Taro.readxl(writetestfile,"t2","A1:E9")
-@test hash(t2) == hash(df)
+@test hash(DataFrame(t2)) == hash(df)
 # TODO: figure out why appending to a file causes segfault
 # Taro.writexl(writetestfile, [df]; append=true)
 # t3 = Taro.readxl(writetestfile,2,"A1:E9")
@@ -36,9 +41,9 @@ rm(writetestfile; force=true)
 Taro.writexl(writetestfile, [df, df])
 # Taro.writexl(writetestfile, [df]; sheetnames=["df3"], append=true)
 t1 = Taro.readxl(writetestfile,0,"A1:E9")
-@test hash(t1) == hash(df)
+@test hash(DataFrame(t1)) == hash(df)
 t2 = Taro.readxl(writetestfile,1,"A1:E9")
-@test hash(t2) == hash(df)
+@test hash(DataFrame(t2)) == hash(df)
 # t3 = Taro.readxl(writetestfile,2,"A1:E9")
 # @test hash(t3) == hash(df)
 
@@ -46,7 +51,7 @@ t2 = Taro.readxl(writetestfile,1,"A1:E9")
 rm(writetestfile; force=true)
 
 #Test Date Routines
-t=now()
+t=Dates.now()
 @assert fromExcelDate(getExcelDate(t)) - t == Dates.Millisecond(0)
 
 #Workbook


### PR DESCRIPTION
One major backward incompatible change:

`readxl` now returns an array of NamedTuples. To get a `DataFrame` as before, pass that to a `DataFrame` constructor. This change allows you to create any Tables.jl supported container from the xl data. As a result, the dependency on DataFrames.jl is dropped. Instead a dependency on Tables.jl is introduced. 

Fix #46 

viz:
```
nt = Taro.readxl("/path/to/file.xlsx", "A1:B10")
using DataFrame
df = DataFrame(nt)
```