### PR TITLE
Set JavaCall 0.8.x compatability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ JavaCall = "494afd89-becb-516b-aafa-70d2670c0337"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-JavaCall = "0.7"
+JavaCall = "0.7, 0.8"
 Tables = "0.2, 1"
 julia = "1"
 


### PR DESCRIPTION
We're actively testing JavaCall against Taro, so JavaCall 0.8.x should work with Taro