### PR TITLE
Expand Travis CI for Taro.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,44 @@
 language: julia
 os:
   - linux
+  - osx
+  - windows
+dist: bionic
+before_install:
+  - source ${TRAVIS_BUILD_DIR}/test/windows_java.sh
 julia:
   - 1.0
+  - 1
   - nightly
+
+env:
+  - JULIA_COPY_STACKS=0
+  - JULIA_COPY_STACKS=1
+
+jobs:
+  include:
+  - julia: 1
+    env: JULIA_COPY_STACKS=1 JAVA_HOME=/usr/local/lib/jvm/openjdk8
+    os: linux
+  - julia: 1
+    env: JULIA_COPY_STACKS=1 JAVA_HOME=/usr/local/lib/jvm/openjdk11
+    os: linux
+  - julia: 1
+    env: JULIA_COPY_STACKS=1
+    os: osx
+    osx_image: xcode9.3
+  - julia: 1
+    env: JULIA_COPY_STACKS=0 JAVA_PKG=openjdk8
+    os: windows
+  exclude:
+  - julia: 1.0
+    env: JULIA_COPY_STACKS=0
+  - julia: 1.0
+    os: windows
+    env: JULIA_COPY_STACKS=1
+  allow_failures:
+  - julia: nightly
+  - os: windows
+    env: JULIA_COPY_STACKS=1
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@ Taro is a utility belt of functions to work with document files in Julia. It use
 Documentation is available at [http://aviks.github.io/Taro.jl/](http://aviks.github.io/Taro.jl/)
 
 [![Build Status](https://travis-ci.org/aviks/Taro.jl.png)](https://travis-ci.org/aviks/Taro.jl) [![Build status](https://ci.appveyor.com/api/projects/status/fjxar3dun9pr3aay?svg=true)](https://ci.appveyor.com/project/aviks/taro-jl)
- [![Taro](http://pkg.julialang.org/badges/Taro_0.3.svg)](http://pkg.julialang.org/?pkg=Taro&ver=release) [![Taro](http://pkg.julialang.org/badges/Taro_0.4.svg)](http://pkg.julialang.org/?pkg=Taro&ver=nightly) [![Taro](http://pkg.julialang.org/badges/Taro_0.5.svg)](http://pkg.julialang.org/?pkg=Taro&ver=nightly) [![Taro](http://pkg.julialang.org/badges/Taro_0.6.svg)](http://pkg.julialang.org/?pkg=Taro&ver=nightly)

--- a/test/windows_java.sh
+++ b/test/windows_java.sh
@@ -1,0 +1,11 @@
+if [ $TRAVIS_OS_NAME == "windows" ]; then
+    #From https://travis-ci.community/t/java-support-on-windows/286/7
+    #export JAVA_HOME=${JAVA_HOME:-/c/jdk}
+    #export PATH=${JAVA_HOME}/bin:${PATH}
+    #choco install jdk8 -params 'installdir=c:\\jdk' -y
+    choco install ${JAVA_PKG:="openjdk11"}
+    #export JAVA_HOME="C:\Program Files\OpenJDK\openjdk-11.0.5_10"
+    JAVA_ROOT_DIR='C:\Program Files\OpenJDK\'
+    export JAVA_HOME=${JAVA_HOME:-`find "$JAVA_ROOT_DIR" -name "openjdk*" | tail -n 1`}
+fi
+echo "JAVA_HOME: "$JAVA_HOME


### PR DESCRIPTION
I copied over the JavaCall.jl Travis configuration from JavaCall to expand testing to Mac and Windows