### PR TITLE
Use apache archive for fop-2.3

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ fop_gz = joinpath(tdeps, "fop-2.3-bin.tar.gz")
 
 if !isfile(fop_gz)
     @info "  Downloading fop-2.3 binary from Apache OSUOSL Mirror"
-    download("https://apache.osuosl.org/xmlgraphics/fop/binaries/fop-2.3-bin.tar.gz", fop_gz)
+    download("https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-2.3-bin.tar.gz", fop_gz)
 end
 if !isfile(fop_jar)
     if Sys.isunix() unpack_cmd = `tar xzf $fop_gz --directory=$tdeps` end


### PR DESCRIPTION
@aviks This is my alternative to #63 that preserves the version of the dependency. I had initally included this in #54 thinking it needed to be changed then, but I reverted it before creating the pull request. 

This closes #62.

/cc @mkitti @nosferican